### PR TITLE
Feature/bottom signature position

### DIFF
--- a/yousign_connector/i18n/fr.po
+++ b/yousign_connector/i18n/fr.po
@@ -1,43 +1,28 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-#	* yousign_connector
+# 	* yousign_connector
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 8.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-02-05 16:38+0000\n"
-"PO-Revision-Date: 2018-02-05 16:38+0000\n"
+"POT-Creation-Date: 2023-04-20 07:59+0000\n"
+"PO-Revision-Date: 2023-04-20 15:41+0200\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
+"Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: \n"
+"X-Generator: Poedit 2.4.2\n"
 
 #. module: yousign_connector
-#: code:addons/yousign_connector/models/yousign_request.py:581
-#, python-format
-msgid "%d signed document(s) have been added as attachment"
+#: code:addons/yousign_connector/models/yousign_request.py:796
+#, fuzzy, python-format
+#| msgid "%d signed document(s) have been added as attachment"
+msgid "%d signed document(s) are now attached. Request %s is archived"
 msgstr "%d documents signés ont été ajoutés en pièce jointe"
-
-#. module: yousign_connector
-#: code:addons/yousign_connector/models/yousign_request.py:557
-#, python-format
-msgid "<b>Failed to archive signed documents.</b><br/>Technical error: %s"
-msgstr "<b>Échec de l'archivage des documents signés.</b><br/>Erreur technique : %s"
-
-#. module: yousign_connector
-#: code:addons/yousign_connector/models/yousign_request.py:519
-#, python-format
-msgid "<b>Failed to send reminder to late signatories.</b> <br/>Technical error: %s"
-msgstr "<b>Échec de l'envoi de la relance aux signataires retardataires.</b> <br/>Erreur technique : %s"
-
-#. module: yousign_connector
-#: code:addons/yousign_connector/models/yousign_request.py:428
-#, python-format
-msgid "<b>Failed to update status</b>. <br/>Technical error: %s"
-msgstr "<b>Échec de la mise à jour du statut.</b> <br/>Erreur technique : %s"
 
 #. module: yousign_connector
 #: view:yousign.request.template:yousign_connector.yousign_request_template_form
@@ -61,31 +46,49 @@ msgid "Archived"
 msgstr "Archivé"
 
 #. module: yousign_connector
-#: view:yousign.request:yousign_connector.yousign_request_form
-msgid "Ask Yousign to send reminder to signatories"
-msgstr "Demander à Yousign d'envoyer une relance aux signataires retardataires"
-
-#. module: yousign_connector
-#: field:yousign.request.signatory,auth_value:0
-msgid "Auth value"
-msgstr "Valeur d'auth."
-
-#. module: yousign_connector
 #: field:yousign.request.signatory,auth_mode:0
 #: field:yousign.request.template.signatory,auth_mode:0
 msgid "Authentication Mode"
 msgstr "Mode d'authentification"
 
 #. module: yousign_connector
-#: field:yousign.request.template.signatory,auth_value:0
-msgid "Authentication Value"
-msgstr "Valeur d'authentification"
-
-#. module: yousign_connector
 #: help:yousign.request.signatory,auth_mode:0
 #: help:yousign.request.template.signatory,auth_mode:0
 msgid "Authentication mode used for the signer"
 msgstr "Mode d'authentification utilisé pour le signataire"
+
+#. module: yousign_connector
+#: view:yousign.request:yousign_connector.new_yousign_request_form
+#: view:yousign.request:yousign_connector.yousign_request_form
+#: view:yousign.request.template:yousign_connector.yousign_request_template_form
+msgid "Auto-Remind Setup"
+msgstr ""
+
+#. module: yousign_connector
+#: field:yousign.request,remind_auto:0
+#: field:yousign.request.template,remind_auto:0
+msgid "Automatic Reminder"
+msgstr ""
+
+#. module: yousign_connector
+#: view:yousign.request:yousign_connector.new_yousign_request_form
+#: field:yousign.request.notification,body:0
+#: view:yousign.request.template:yousign_connector.yousign_request_template_form
+#: field:yousign.request.template.notification,body:0
+msgid "Body"
+msgstr ""
+
+#. module: yousign_connector
+#: selection:yousign.request,sign_position:0
+#: selection:yousign.request.template,sign_position:0
+msgid "Bottom"
+msgstr "En bas du document"
+
+#. module: yousign_connector
+#: field:yousign.request.signatory,mention_bottom:0
+#: field:yousign.request.template.signatory,mention_bottom:0
+msgid "Bottom Mention"
+msgstr ""
 
 #. module: yousign_connector
 #: view:yousign.request:yousign_connector.new_yousign_request_form
@@ -105,35 +108,43 @@ msgid "Check if signatories have signed the documents"
 msgstr "Vérifie si les signataires ont signé les documents"
 
 #. module: yousign_connector
+#: field:yousign.request.signatory,comment:0
+msgid "Comment"
+msgstr ""
+
+#. module: yousign_connector
 #: field:yousign.request,company_id:0
 #: field:yousign.request.template,company_id:0
 msgid "Company"
 msgstr "Société"
 
 #. module: yousign_connector
-#: help:yousign.request.template,message:0
-msgid "Corresponding field in Yousign API : message"
-msgstr "Champ correspondant dans l'API Yousign : message"
-
-#. module: yousign_connector
-#: help:yousign.request.template,title:0
-msgid "Corresponding field in Yousign API : title"
-msgstr "Champ correspondant dans l'API Yousign : title"
+#: code:addons/yousign_connector/models/yousign_request.py:312
+#, python-format
+msgid ""
+"Connection to %s failed. Check the Internet connection of the Odoo server.\n"
+"\n"
+"Error details: %s"
+msgstr ""
 
 #. module: yousign_connector
 #: field:yousign.request,create_uid:0
+#: field:yousign.request.notification,create_uid:0
 #: field:yousign.request.remind,create_uid:0
 #: field:yousign.request.signatory,create_uid:0
 #: field:yousign.request.template,create_uid:0
+#: field:yousign.request.template.notification,create_uid:0
 #: field:yousign.request.template.signatory,create_uid:0
 msgid "Created by"
 msgstr "Créé par"
 
 #. module: yousign_connector
 #: field:yousign.request,create_date:0
+#: field:yousign.request.notification,create_date:0
 #: field:yousign.request.remind,create_date:0
 #: field:yousign.request.signatory,create_date:0
 #: field:yousign.request.template,create_date:0
+#: field:yousign.request.template.notification,create_date:0
 #: field:yousign.request.template.signatory,create_date:0
 msgid "Created on"
 msgstr "Créé le"
@@ -149,9 +160,24 @@ msgid "Default Report to Sign"
 msgstr "Rapport à signer par défaut"
 
 #. module: yousign_connector
+#: field:yousign.request,display_name:0
+#: field:yousign.request.notification,display_name:0
+#: field:yousign.request.remind,display_name:0
+#: field:yousign.request.signatory,display_name:0
+#: field:yousign.request.template,display_name:0
+#: field:yousign.request.template.notification,display_name:0
+#: field:yousign.request.template.signatory,display_name:0
+msgid "Display Name"
+msgstr ""
+
+#. module: yousign_connector
 #: view:yousign.request.template:yousign_connector.yousign_request_template_form
-msgid "Display an option on related documents to open a composition wizard with this template"
-msgstr "Display an option on related documents to open a composition wizard with this template"
+msgid ""
+"Display an option on related documents to open a composition wizard with "
+"this template"
+msgstr ""
+"Display an option on related documents to open a composition wizard with "
+"this template"
 
 #. module: yousign_connector
 #: field:yousign.request,attachment_ids:0
@@ -181,10 +207,20 @@ msgid "Dynamic Partner"
 msgstr "Partenaire dynamique"
 
 #. module: yousign_connector
-#: code:addons/yousign_connector/models/yousign_request_template.py:141
+#: code:addons/yousign_connector/models/yousign_request_template.py:164
 #, python-format
 msgid "Dynamic Partner is required when Partner Type is set to 'Dynamic'"
-msgstr "Un partenaire dynamique est requis quand le type de partenaire est 'Dynamique'"
+msgstr ""
+"Un partenaire dynamique est requis quand le type de partenaire est "
+"'Dynamique'"
+
+#. module: yousign_connector
+#: selection:yousign.request.signatory,auth_mode:0
+#: selection:yousign.request.template.signatory,auth_mode:0
+#, fuzzy
+#| msgid "Mail"
+msgid "E-Mail"
+msgstr "Mail"
 
 #. module: yousign_connector
 #: field:yousign.request.signatory,email:0
@@ -192,30 +228,42 @@ msgid "E-mail"
 msgstr "E-mail"
 
 #. module: yousign_connector
-#: code:addons/yousign_connector/models/yousign_request.py:239
-#, python-format
-msgid "Failed to initialize connection to Yousign with username %s on environment %s. \n"
-"\n"
-"Technical error message: %s"
-msgstr "Échec de l'initialisation de la connexion vers Yousign avec le login %s sur l'environnement %s. \n"
-"\n"
-"Message d'erreur technique : %s"
+#: view:yousign.request:yousign_connector.new_yousign_request_form
+#: view:yousign.request:yousign_connector.yousign_request_form
+#: field:yousign.request,notification_ids:0
+#: view:yousign.request.template:yousign_connector.yousign_request_template_form
+#: field:yousign.request.template,notification_ids:0
+msgid "E-mail Notifications"
+msgstr ""
 
 #. module: yousign_connector
-#: code:addons/yousign_connector/models/yousign_request.py:384
+#: view:yousign.request:yousign_connector.yousign_request_form
+#, fuzzy
+#| msgid "E-mail"
+msgid "Email"
+msgstr "E-mail"
+
+#. module: yousign_connector
+#: code:addons/yousign_connector/models/yousign_request.py:620
 #, python-format
-msgid "Failure when sending the signing request %s to Yousign.\n"
+msgid ""
+"Failure when sending the signing request %s to Yousign.\n"
 "\n"
 "Error: %s"
-msgstr "Échec de l'envoi de la requête de signature %s à Yousign.\n"
+msgstr ""
+"Échec de l'envoi de la requête de signature %s à Yousign.\n"
 "\n"
 "Erreur: %s"
 
 #. module: yousign_connector
-#: code:addons/yousign_connector/models/yousign_request.py:344
+#: code:addons/yousign_connector/models/yousign_request.py:524
 #, python-format
-msgid "File to sign '%s' is not a valid PDF file. You must convert it to PDF before including it in a Yousign request."
-msgstr "Le fichier à signer '%s' n'est pas un fichier PDF valide. Vous devez le convertir en PDF avant de l'inclure dans une requête Yousign."
+msgid ""
+"File to sign '%s' is not a valid PDF file. You must convert it to PDF before "
+"including it in a Yousign request."
+msgstr ""
+"Le fichier à signer '%s' n'est pas un fichier PDF valide. Vous devez le "
+"convertir en PDF avant de l'inclure dans une requête Yousign."
 
 #. module: yousign_connector
 #: field:yousign.request.signatory,firstname:0
@@ -228,10 +276,11 @@ msgid "Fixed Partner"
 msgstr "Partenaire fixe"
 
 #. module: yousign_connector
-#: code:addons/yousign_connector/models/yousign_request_template.py:135
+#: code:addons/yousign_connector/models/yousign_request_template.py:158
 #, python-format
 msgid "Fixed Partner is required when Partner Type is set to 'Static'"
-msgstr "Un partenaire fixe est requis quand le type de partenaire est 'Statique'"
+msgstr ""
+"Un partenaire fixe est requis quand le type de partenaire est 'Statique'"
 
 #. module: yousign_connector
 #: field:yousign.request,message_follower_ids:0
@@ -240,25 +289,24 @@ msgstr "Followers"
 
 #. module: yousign_connector
 #: view:yousign.request:yousign_connector.yousign_request_search
+#: view:yousign.request.template:yousign_connector.yousign_request_template_search
 msgid "Group By"
 msgstr "Grouper par"
 
 #. module: yousign_connector
-#: selection:yousign.request.signatory,proof_level:0
-#: selection:yousign.request.template.signatory,proof_level:0
-msgid "High"
-msgstr "Élevé"
-
-#. module: yousign_connector
 #: help:yousign.request,message_summary:0
-msgid "Holds the Chatter summary (number of messages, ...). This summary is directly in html format in order to be inserted in kanban views."
-msgstr "Holds the Chatter summary (number of messages, ...). This summary is directly in html format in order to be inserted in kanban views."
+msgid ""
+"Holds the Chatter summary (number of messages, ...). This summary is "
+"directly in html format in order to be inserted in kanban views."
+msgstr ""
+"Holds the Chatter summary (number of messages, ...). This summary is "
+"directly in html format in order to be inserted in kanban views."
 
 #. module: yousign_connector
-#: field:yousign.request,id:0
-#: field:yousign.request.remind,id:0
-#: field:yousign.request.signatory,id:0
+#: field:yousign.request,id:0 field:yousign.request.notification,id:0
+#: field:yousign.request.remind,id:0 field:yousign.request.signatory,id:0
 #: field:yousign.request.template,id:0
+#: field:yousign.request.template.notification,id:0
 #: field:yousign.request.template.signatory,id:0
 msgid "ID"
 msgstr "ID"
@@ -269,13 +317,41 @@ msgid "If checked new messages require your attention."
 msgstr "If checked new messages require your attention."
 
 #. module: yousign_connector
+#: code:addons/yousign_connector/models/yousign_request.py:421
+#, python-format
+msgid ""
+"In mail body of %s, it seems you tried to include the yousign URL, but the "
+"regular expression didn't match. Please check the special expression for the "
+"yousign URL."
+msgstr ""
+
+#. module: yousign_connector
+#: view:yousign.request:yousign_connector.new_yousign_request_form
+#: view:yousign.request.template:yousign_connector.yousign_request_template_form
+#, fuzzy
+#| msgid "E-mail"
+msgid "Init E-mail"
+msgstr "E-mail"
+
+#. module: yousign_connector
+#: field:yousign.request,init_mail_body:0
+#: field:yousign.request.template,init_mail_body:0
+msgid "Init Mail Body"
+msgstr ""
+
+#. module: yousign_connector
+#: field:yousign.request,init_mail_subject:0
+#: field:yousign.request.template,init_mail_subject:0
+msgid "Init Mail Subject"
+msgstr ""
+
+#. module: yousign_connector
 #: field:yousign.request,message_is_follower:0
 msgid "Is a Follower"
 msgstr "Is a Follower"
 
 #. module: yousign_connector
-#: field:yousign.request,lang:0
-#: field:yousign.request.template,lang:0
+#: field:yousign.request,lang:0 field:yousign.request.template,lang:0
 msgid "Language"
 msgstr "Langue"
 
@@ -285,19 +361,43 @@ msgid "Last Message Date"
 msgstr "Last Message Date"
 
 #. module: yousign_connector
+#: field:yousign.request,__last_update:0
+#: field:yousign.request.notification,__last_update:0
+#: field:yousign.request.remind,__last_update:0
+#: field:yousign.request.signatory,__last_update:0
+#: field:yousign.request.template,__last_update:0
+#: field:yousign.request.template.notification,__last_update:0
+#: field:yousign.request.template.signatory,__last_update:0
+#, fuzzy
+#| msgid "Last Updated on"
+msgid "Last Modified on"
+msgstr "Last Updated on"
+
+#. module: yousign_connector
+#: field:yousign.request,last_update:0
+#, fuzzy
+#| msgid "Last Updated by"
+msgid "Last Status Update"
+msgstr "Last Updated by"
+
+#. module: yousign_connector
 #: field:yousign.request,write_uid:0
+#: field:yousign.request.notification,write_uid:0
 #: field:yousign.request.remind,write_uid:0
 #: field:yousign.request.signatory,write_uid:0
 #: field:yousign.request.template,write_uid:0
+#: field:yousign.request.template.notification,write_uid:0
 #: field:yousign.request.template.signatory,write_uid:0
 msgid "Last Updated by"
 msgstr "Last Updated by"
 
 #. module: yousign_connector
 #: field:yousign.request,write_date:0
+#: field:yousign.request.notification,write_date:0
 #: field:yousign.request.remind,write_date:0
 #: field:yousign.request.signatory,write_date:0
 #: field:yousign.request.template,write_date:0
+#: field:yousign.request.template.notification,write_date:0
 #: field:yousign.request.template.signatory,write_date:0
 msgid "Last Updated on"
 msgstr "Last Updated on"
@@ -308,34 +408,10 @@ msgid "Lastname"
 msgstr "Nom de famille"
 
 #. module: yousign_connector
-#: selection:yousign.request.signatory,proof_level:0
-#: selection:yousign.request.template.signatory,proof_level:0
-msgid "Low"
-msgstr "Faible"
-
-#. module: yousign_connector
-#: selection:yousign.request.signatory,auth_mode:0
-#: selection:yousign.request.template.signatory,auth_mode:0
-msgid "Mail"
-msgstr "Mail"
-
-#. module: yousign_connector
-#: selection:yousign.request.signatory,auth_mode:0
-#: selection:yousign.request.template.signatory,auth_mode:0
-msgid "Manual"
-msgstr "Manuel"
-
-#. module: yousign_connector
-#: selection:yousign.request.signatory,auth_mode:0
-#: selection:yousign.request.template.signatory,auth_mode:0
-msgid "Mass"
-msgstr "En masse"
-
-#. module: yousign_connector
-#: field:yousign.request,message:0
-#: field:yousign.request.template,message:0
-msgid "Message"
-msgstr "Message"
+#: code:addons/yousign_connector/models/yousign_request.py:409
+#, python-format
+msgid "Mail body of %s is empty."
+msgstr ""
 
 #. module: yousign_connector
 #: field:yousign.request,message_ids:0
@@ -348,34 +424,71 @@ msgid "Messages and communication history"
 msgstr "Messages and communication history"
 
 #. module: yousign_connector
-#: code:addons/yousign_connector/models/yousign_request.py:304
+#: code:addons/yousign_connector/models/yousign_request.py:512
+#, python-format
+msgid "Missing ID"
+msgstr ""
+
+#. module: yousign_connector
+#: code:addons/yousign_connector/models/yousign_request.py:492
+#, python-format
+msgid "Missing Remind Mail Body"
+msgstr ""
+
+#. module: yousign_connector
+#: code:addons/yousign_connector/models/yousign_request.py:490
+#, python-format
+msgid "Missing Remind Mail Subject"
+msgstr ""
+
+#. module: yousign_connector
+#: code:addons/yousign_connector/models/yousign_request.py:548
 #, python-format
 msgid "Missing email on the signatory '%s'"
 msgstr "E-mail manquant pour le signataire '%s'"
 
 #. module: yousign_connector
-#: code:addons/yousign_connector/models/yousign_request.py:300
+#: code:addons/yousign_connector/models/yousign_request.py:545
+#, fuzzy, python-format
+#| msgid "Missing email on the signatory '%s'"
+msgid "Missing firstname on signatory '%s'"
+msgstr "E-mail manquant pour le signataire '%s'"
+
+#. module: yousign_connector
+#: code:addons/yousign_connector/models/yousign_request.py:453
+#, fuzzy, python-format
+#| msgid "Missing title on request %s."
+msgid "Missing init mail body on request %s."
+msgstr "Titre manquant sur la requête %s."
+
+#. module: yousign_connector
+#: code:addons/yousign_connector/models/yousign_request.py:449
+#, fuzzy, python-format
+#| msgid "Missing title on request %s."
+msgid "Missing init mail subject on request %s."
+msgstr "Titre manquant sur la requête %s."
+
+#. module: yousign_connector
+#: code:addons/yousign_connector/models/yousign_request.py:541
 #, python-format
 msgid "Missing lastname on one of the signatories of request %s"
 msgstr "Nom de famille manquant sur l'un des signataires de la requête %s"
 
 #. module: yousign_connector
-#: code:addons/yousign_connector/models/yousign_request.py:291
-#, python-format
-msgid "Missing message on request %s."
-msgstr "Message manquant sur la requête %s."
+#: code:addons/yousign_connector/models/yousign_request.py:552
+#, fuzzy, python-format
+#| msgid "Missing email on the signatory '%s'"
+msgid "Missing mobile phone number on signatory '%s'."
+msgstr "E-mail manquant pour le signataire '%s'"
 
 #. module: yousign_connector
-#: code:addons/yousign_connector/models/yousign_request.py:307
+#: code:addons/yousign_connector/models/yousign_request.py:415
 #, python-format
-msgid "Missing mobile phone number on signatory '%s' whose authentication mode is SMS"
-msgstr "Numéro de téléphone portable manquant sur le signataire '%s' dont le mode d'authentification est SMS"
-
-#. module: yousign_connector
-#: code:addons/yousign_connector/models/yousign_request.py:288
-#, python-format
-msgid "Missing title on request %s."
-msgstr "Titre manquant sur la requête %s."
+msgid ""
+"Missing special tag {yousignUrl|Access to documents} in the mail body of %s. "
+"The special tag will be replaced by the button with the label 'Access to "
+"documents'."
+msgstr ""
 
 #. module: yousign_connector
 #: field:yousign.request.signatory,mobile:0
@@ -388,14 +501,20 @@ msgid "Model"
 msgstr "Objet"
 
 #. module: yousign_connector
-#: field:yousign.request,name:0
-#: field:yousign.request.template,name:0
+#: field:yousign.request,name:0 field:yousign.request.template,name:0
 msgid "Name"
 msgstr "Nom"
 
 #. module: yousign_connector
+#: view:yousign.request.template:yousign_connector.yousign_request_template_search
+msgid "Name or Mail Subject"
+msgstr ""
+
+#. module: yousign_connector
 #: view:yousign.request:yousign_connector.yousign_request_search
-msgid "Name, Document Name or Title"
+#, fuzzy
+#| msgid "Name, Document Name or Title"
+msgid "Name, Document Name or Mail Subject"
 msgstr "Nom, nom du document ou titre"
 
 #. module: yousign_connector
@@ -404,26 +523,70 @@ msgid "New Yousign Request"
 msgstr "Nouvelle requête Yousign"
 
 #. module: yousign_connector
-#: code:addons/yousign_connector/models/yousign_request.py:131
+#: code:addons/yousign_connector/models/yousign_request.py:179
 #, python-format
 msgid "No Yousign Request Template for model %s"
 msgstr "Aucun modèle de requête Yousign pour l'objet %s"
 
 #. module: yousign_connector
+#: field:yousign.request.notification,notif_type:0
+#: field:yousign.request.template.notification,notif_type:0
+msgid "Notification Type"
+msgstr ""
+
+#. module: yousign_connector
+#: model:ir.model,name:yousign_connector.model_yousign_request_notification
+#, fuzzy
+#| msgid "Signatories of Yousign Request Template"
+msgid "Notifications of Yousign Request"
+msgstr "Signataires du modèle de requête Yousign"
+
+#. module: yousign_connector
+#: model:ir.model,name:yousign_connector.model_yousign_request_template_notification
+#, fuzzy
+#| msgid "Signatories of Yousign Request Template"
+msgid "Notifications of Yousign Request Template"
+msgstr "Signataires du modèle de requête Yousign"
+
+#. module: yousign_connector
+#: field:yousign.request.notification,creator:0
+#: field:yousign.request.template.notification,creator:0
+msgid "Notify Creator"
+msgstr ""
+
+#. module: yousign_connector
+#: field:yousign.request.notification,members:0
+#: field:yousign.request.template.notification,members:0
+msgid "Notify Members"
+msgstr ""
+
+#. module: yousign_connector
+#: field:yousign.request.notification,subscribers:0
+#: field:yousign.request.template.notification,subscribers:0
+msgid "Notify Subscribers"
+msgstr ""
+
+#. module: yousign_connector
+#: help:yousign.request,remind_interval:0
+#: help:yousign.request.template,remind_interval:0
+msgid "Number of days between 2 auto-reminders by email."
+msgstr ""
+
+#. module: yousign_connector
 #: view:yousign.request:yousign_connector.yousign_request_search
+#: view:yousign.request.template:yousign_connector.yousign_request_template_search
 msgid "Object"
 msgstr "Objet"
 
 #. module: yousign_connector
-#: code:addons/yousign_connector/models/yousign_request.py:223
+#: code:addons/yousign_connector/models/yousign_request.py:280
 #, python-format
-msgid "One of the Yousign config parameters is missing in the Odoo server config file."
-msgstr "Un des paramètres de configuration Yousign est manquant dans le fichier de configuration du serveur Odoo."
-
-#. module: yousign_connector
-#: selection:yousign.request.signatory,state:0
-msgid "Partially Signed"
-msgstr "Partiellement signé"
+msgid ""
+"One of the Yousign config parameters is missing in the Odoo server config "
+"file."
+msgstr ""
+"Un des paramètres de configuration Yousign est manquant dans le fichier de "
+"configuration du serveur Odoo."
 
 #. module: yousign_connector
 #: field:yousign.request.signatory,partner_id:0
@@ -436,27 +599,22 @@ msgid "Partner Type"
 msgstr "Type de partenaire"
 
 #. module: yousign_connector
+#: field:yousign.request.notification,partner_ids:0
+#: field:yousign.request.template.notification,partner_ids:0
+#, fuzzy
+#| msgid "Partner Type"
+msgid "Partners to Notify"
+msgstr "Type de partenaire"
+
+#. module: yousign_connector
 #: selection:yousign.request.signatory,state:0
 msgid "Pending"
 msgstr "En attente"
 
 #. module: yousign_connector
-#: selection:yousign.request.signatory,auth_mode:0
-#: selection:yousign.request.template.signatory,auth_mode:0
-msgid "Photo"
-msgstr "Photo"
-
-#. module: yousign_connector
-#: field:yousign.request.signatory,proof_level:0
-#: field:yousign.request.template.signatory,proof_level:0
-msgid "Proof Level"
-msgstr "Niveau de preuve"
-
-#. module: yousign_connector
-#: help:yousign.request.signatory,proof_level:0
-#: help:yousign.request.template.signatory,proof_level:0
-msgid "Proof level of the signer. In HIGH mode, signer(s) must upload ID cards to launch the signature (it will be checked immediately after the upload)"
-msgstr "Niveau de preuve du signataire. En mode élevé, les signataires doivent déposer une copie d'une pièce d'identité (elle sera vérifiée juste après le dépôt)"
+#: selection:yousign.request.signatory,state:0
+msgid "Refused"
+msgstr ""
 
 #. module: yousign_connector
 #: field:yousign.request,res_id:0
@@ -474,15 +632,33 @@ msgid "Related Document Name"
 msgstr "Nom du document associé"
 
 #. module: yousign_connector
+#: field:yousign.request,remind_interval:0
+#: field:yousign.request.template,remind_interval:0
+msgid "Remind Interval"
+msgstr ""
+
+#. module: yousign_connector
+#: field:yousign.request,remind_limit:0
+#: field:yousign.request.template,remind_limit:0
+msgid "Remind Limit"
+msgstr ""
+
+#. module: yousign_connector
 #: model:ir.model,name:yousign_connector.model_yousign_request_remind
 msgid "Remind several Yousign requests"
 msgstr "Relance sur plusieurs requêtes Yousign"
 
 #. module: yousign_connector
-#: code:addons/yousign_connector/models/yousign_request.py:512
-#, python-format
-msgid "Reminder sent to late signatories"
-msgstr "Relance envoyée aux signataires retardataires"
+#: field:yousign.request,remind_mail_body:0
+#: field:yousign.request.template,remind_mail_body:0
+msgid "Reminder Mail Body"
+msgstr ""
+
+#. module: yousign_connector
+#: field:yousign.request,remind_mail_subject:0
+#: field:yousign.request.template,remind_mail_subject:0
+msgid "Reminder Mail Subject"
+msgstr ""
 
 #. module: yousign_connector
 #: view:yousign.request.template:yousign_connector.yousign_request_template_form
@@ -492,9 +668,11 @@ msgstr "Retirer l'action"
 #. module: yousign_connector
 #: view:yousign.request.template:yousign_connector.yousign_request_template_form
 msgid "Remove the contextual action to use this template on related documents"
-msgstr "Retire l'action contextuelle liée à ce modèle sur les documents associés"
+msgstr ""
+"Retire l'action contextuelle liée à ce modèle sur les documents associés"
 
 #. module: yousign_connector
+#: field:yousign.request.notification,parent_id:0
 #: field:yousign.request.signatory,parent_id:0
 msgid "Request"
 msgstr "Requête"
@@ -506,10 +684,23 @@ msgid "Request Templates"
 msgstr "Modèles de requêtes"
 
 #. module: yousign_connector
+#: code:addons/yousign_connector/models/yousign_request.py:646
+#, python-format
+msgid "Request successfully cancelled via Yousign webservices."
+msgstr ""
+
+#. module: yousign_connector
 #: selection:yousign.request.signatory,auth_mode:0
 #: selection:yousign.request.template.signatory,auth_mode:0
 msgid "SMS"
 msgstr "SMS"
+
+#. module: yousign_connector
+#: view:yousign.request.template:yousign_connector.yousign_request_template_search
+#, fuzzy
+#| msgid "Yousign Request Templates"
+msgid "Search Yousign Request Templates"
+msgstr "Modèles de requête Yousign"
 
 #. module: yousign_connector
 #: view:yousign.request:yousign_connector.yousign_request_search
@@ -518,7 +709,6 @@ msgstr "Search Yousign Requests"
 
 #. module: yousign_connector
 #: model:ir.actions.act_window,name:yousign_connector.yousign_request_remind_action
-#: view:yousign.request:yousign_connector.yousign_request_form
 #: view:yousign.request.remind:yousign_connector.yousign_request_remind_form
 msgid "Send Reminder"
 msgstr "Envoyer une relance"
@@ -553,13 +743,28 @@ msgstr "Sidebar Button"
 
 #. module: yousign_connector
 #: help:yousign.request.template,ir_act_window_id:0
-msgid "Sidebar action to make this template available on records of the related document model"
-msgstr "Sidebar action to make this template available on records of the related document model"
+msgid ""
+"Sidebar action to make this template available on records of the related "
+"document model"
+msgstr ""
+"Sidebar action to make this template available on records of the related "
+"document model"
 
 #. module: yousign_connector
 #: help:yousign.request.template,ir_value_id:0
 msgid "Sidebar button to open the sidebar action"
 msgstr "Sidebar button to open the sidebar action"
+
+#. module: yousign_connector
+#: field:yousign.request,ordered:0 field:yousign.request.template,ordered:0
+msgid "Sign one after the other"
+msgstr ""
+
+#. module: yousign_connector
+#: field:yousign.request,sign_position:0
+#: field:yousign.request.template,sign_position:0
+msgid "Sign position"
+msgstr "Emplacement des signatures"
 
 #. module: yousign_connector
 #: view:yousign.request:yousign_connector.new_yousign_request_form
@@ -574,6 +779,13 @@ msgstr "Signataires"
 #: model:ir.model,name:yousign_connector.model_yousign_request_template_signatory
 msgid "Signatories of Yousign Request Template"
 msgstr "Signataires du modèle de requête Yousign"
+
+#. module: yousign_connector
+#: field:yousign.request.signatory,signature_date:0
+#, fuzzy
+#| msgid "Signature Status"
+msgid "Signature Date"
+msgstr "État des signatures"
 
 #. module: yousign_connector
 #: model:ir.actions.act_window,name:yousign_connector.new_yousign_request_action
@@ -599,6 +811,13 @@ msgid "Signed"
 msgstr "Signé"
 
 #. module: yousign_connector
+#: field:yousign.request,signed_attachment_ids:0
+#, fuzzy
+#| msgid "Related Document ID"
+msgid "Signed Documents"
+msgstr "ID du document associé"
+
+#. module: yousign_connector
 #: view:yousign.request:yousign_connector.yousign_request_search
 #: field:yousign.request,state:0
 msgid "State"
@@ -610,43 +829,99 @@ msgid "Static"
 msgstr "Statique"
 
 #. module: yousign_connector
+#: view:yousign.request:yousign_connector.new_yousign_request_form
+#: field:yousign.request.notification,subject:0
+#: view:yousign.request.template:yousign_connector.yousign_request_template_form
+#: field:yousign.request.template.notification,subject:0
+#, fuzzy
+#| msgid "Object"
+msgid "Subject"
+msgstr "Objet"
+
+#. module: yousign_connector
 #: field:yousign.request,message_summary:0
 msgid "Summary"
 msgstr "Summary"
 
 #. module: yousign_connector
+#: code:addons/yousign_connector/models/yousign_request.py:322
+#, python-format
+msgid ""
+"Technical failure when trying to connect to Yousign.\n"
+"\n"
+"Error details: URL %s method %s. Error: %s"
+msgstr ""
+
+#. module: yousign_connector
+#: field:yousign.request.template.notification,parent_id:0
 #: field:yousign.request.template.signatory,parent_id:0
 msgid "Template"
 msgstr "Modèle"
 
 #. module: yousign_connector
-#: code:addons/yousign_connector/models/yousign_request.py:284
+#: code:addons/yousign_connector/models/yousign_request.py:340
+#, python-format
+msgid ""
+"The HTTP %s request on Yousign webservice %s returned status code %d whereas "
+"%d was expected. Error message: %s (%s)."
+msgstr ""
+
+#. module: yousign_connector
+#: sql_constraint:yousign.request:0 sql_constraint:yousign.request.template:0
+msgid "The Remind Interval must be positive or null."
+msgstr ""
+
+#. module: yousign_connector
+#: sql_constraint:yousign.request:0 sql_constraint:yousign.request.template:0
+msgid "The Remind Limit must be positive or null."
+msgstr ""
+
+#. module: yousign_connector
+#: code:addons/yousign_connector/models/yousign_request.py:445
 #, python-format
 msgid "There are no documents to sign on request %s!"
 msgstr "Il n'y a aucun document à signer sur la requête %s !"
 
 #. module: yousign_connector
-#: code:addons/yousign_connector/models/yousign_request.py:281
+#: code:addons/yousign_connector/models/yousign_request.py:442
 #, python-format
 msgid "There are no signatories on request %s!"
 msgstr "Il n'y a aucun signataire sur la requête %s !"
 
 #. module: yousign_connector
+#: sql_constraint:yousign.request.template.notification:0
+msgid ""
+"This notification type already exists for this Yousign request template!"
+msgstr ""
+
+#. module: yousign_connector
+#: sql_constraint:yousign.request.notification:0
+msgid "This notification type already exists for this Yousign request!"
+msgstr ""
+
+#. module: yousign_connector
 #: view:yousign.request.remind:yousign_connector.yousign_request_remind_form
-msgid "This wizard will ask YouSign to send a reminder to all the selected requests."
-msgstr "Cet assistant demandera à YouSign d'envoyer une relance à toutes les requêtes sélectionnées."
+#, fuzzy
+#| msgid ""
+#| "This wizard will ask YouSign to send a reminder to all the selected "
+#| "requests."
+msgid ""
+"This wizard will ask Yousign to send a reminder to all the selected requests."
+msgstr ""
+"Cet assistant demandera à YouSign d'envoyer une relance à toutes les "
+"requêtes sélectionnées."
 
 #. module: yousign_connector
-#: field:yousign.request,title:0
-#: field:yousign.request.template,title:0
-msgid "Title"
-msgstr "Titre"
+#: selection:yousign.request,sign_position:0
+#: selection:yousign.request.template,sign_position:0
+msgid "Top"
+msgstr "En haut du document"
 
 #. module: yousign_connector
-#: help:yousign.request.signatory,auth_value:0
-#: help:yousign.request.template.signatory,auth_value:0
-msgid "To be set only when Authentication Mode is Manual"
-msgstr "À renseigner uniquement quand le mode d'authentification est 'manuel'"
+#: field:yousign.request.signatory,mention_top:0
+#: field:yousign.request.template.signatory,mention_top:0
+msgid "Top Mention"
+msgstr ""
 
 #. module: yousign_connector
 #: field:yousign.request,message_unread:0
@@ -654,7 +929,7 @@ msgid "Unread Messages"
 msgstr "Unread Messages"
 
 #. module: yousign_connector
-#: code:addons/yousign_connector/models/yousign_request_template.py:157
+#: code:addons/yousign_connector/models/yousign_request_template.py:180
 #, python-format
 msgid "Unsupported partner type"
 msgstr "Type de partenaire non supporté"
@@ -665,33 +940,31 @@ msgid "Update"
 msgstr "Mettre à jour"
 
 #. module: yousign_connector
-#: code:addons/yousign_connector/models/yousign_request.py:135
+#: code:addons/yousign_connector/models/yousign_request.py:183
 #, python-format
 msgid "Wrong active_model (%s should be %s)"
 msgstr "Wrong active_model (%s should be %s)"
 
 #. module: yousign_connector
-#: code:addons/yousign_connector/models/yousign_request.py:312
-#, python-format
-msgid "You have selected 'manual' as authentication mode for the signatory %s, so you must set the authentication value for this signatory."
-msgstr "Vous avez sélectionné le mode d'authentification 'manuel' pour le signataire %s, donc vous devez entrer une valeur d'authentification pour ce signataire."
+#: code:addons/yousign_connector/models/yousign_request.py:510
+#, fuzzy, python-format
+#| msgid "Wrong active_model (%s should be %s)"
+msgid "Wrong status, should be draft"
+msgstr "Wrong active_model (%s should be %s)"
 
 #. module: yousign_connector
-#: field:yousign.request,ys_lang:0
-msgid "Yousign Lang"
-msgstr "Langue Yousign"
+#: help:yousign.request.template,init_mail_body:0
+msgid ""
+"You must insert '{yousignUrl}' in the body where you want to insert the URL "
+"to access Yousign."
+msgstr ""
 
 #. module: yousign_connector
-#: code:addons/yousign_connector/models/yousign_request.py:396
+#: code:addons/yousign_connector/models/yousign_request.py:906
+#: code:addons/yousign_connector/models/yousign_request_template.py:235
 #, python-format
-msgid "Yousign request <b>%s</b> generated with %d signatories"
-msgstr "Requête Yousign <b>%s</b> générée avec %d signataires"
-
-#. module: yousign_connector
-#: code:addons/yousign_connector/models/yousign_request.py:476
-#, python-format
-msgid "Yousign request <b>%s</b> has been signed by all signatories"
-msgstr "La requête Yousign <b>%s</b> a été signée par tous les signataires"
+msgid "You must select who should be notified."
+msgstr ""
 
 #. module: yousign_connector
 #: model:ir.ui.menu,name:yousign_connector.yousign_root_config
@@ -711,7 +984,7 @@ msgid "Yousign Request"
 msgstr "Requête Yousign"
 
 #. module: yousign_connector
-#: code:addons/yousign_connector/models/yousign_request_template.py:51
+#: code:addons/yousign_connector/models/yousign_request_template.py:78
 #, python-format
 msgid "Yousign Request (%s)"
 msgstr "Requête Yousign (%s)"
@@ -750,8 +1023,146 @@ msgid "Yousign Requests"
 msgstr "Requêtes Yousign"
 
 #. module: yousign_connector
-#: code:addons/yousign_connector/models/yousign_request_template.py:152
+#: code:addons/yousign_connector/models/yousign_request.py:632
 #, python-format
-msgid "dynamic_partner_id is a required argument when partner_type is dynamic"
-msgstr "dynamic_partner_id is a required argument when partner_type is dynamic"
+msgid "Yousign request <b>%s</b> generated with %d signatories"
+msgstr "Requête Yousign <b>%s</b> générée avec %d signataires"
 
+#. module: yousign_connector
+#: code:addons/yousign_connector/models/yousign_request.py:703
+#, python-format
+msgid "Yousign request <b>%s</b> has been signed by all signatories"
+msgstr "La requête Yousign <b>%s</b> a été signée par tous les signataires"
+
+#. module: yousign_connector
+#: view:yousign.request:yousign_connector.new_yousign_request_form
+#: view:yousign.request:yousign_connector.yousign_request_form
+#: view:yousign.request.template:yousign_connector.yousign_request_template_form
+msgid "days"
+msgstr ""
+
+#. module: yousign_connector
+#: code:addons/yousign_connector/models/yousign_request.py:345
+#, python-format
+msgid "no detail"
+msgstr ""
+
+#, python-format
+#~ msgid "<b>Failed to archive signed documents.</b><br/>Technical error: %s"
+#~ msgstr ""
+#~ "<b>Échec de l'archivage des documents signés.</b><br/>Erreur technique : "
+#~ "%s"
+
+#, python-format
+#~ msgid ""
+#~ "<b>Failed to send reminder to late signatories.</b> <br/>Technical error: "
+#~ "%s"
+#~ msgstr ""
+#~ "<b>Échec de l'envoi de la relance aux signataires retardataires.</b> <br/"
+#~ ">Erreur technique : %s"
+
+#, python-format
+#~ msgid "<b>Failed to update status</b>. <br/>Technical error: %s"
+#~ msgstr ""
+#~ "<b>Échec de la mise à jour du statut.</b> <br/>Erreur technique : %s"
+
+#~ msgid "Ask Yousign to send reminder to signatories"
+#~ msgstr ""
+#~ "Demander à Yousign d'envoyer une relance aux signataires retardataires"
+
+#~ msgid "Auth value"
+#~ msgstr "Valeur d'auth."
+
+#~ msgid "Authentication Value"
+#~ msgstr "Valeur d'authentification"
+
+#~ msgid "Corresponding field in Yousign API : message"
+#~ msgstr "Champ correspondant dans l'API Yousign : message"
+
+#~ msgid "Corresponding field in Yousign API : title"
+#~ msgstr "Champ correspondant dans l'API Yousign : title"
+
+#, python-format
+#~ msgid ""
+#~ "Failed to initialize connection to Yousign with username %s on "
+#~ "environment %s. \n"
+#~ "\n"
+#~ "Technical error message: %s"
+#~ msgstr ""
+#~ "Échec de l'initialisation de la connexion vers Yousign avec le login %s "
+#~ "sur l'environnement %s. \n"
+#~ "\n"
+#~ "Message d'erreur technique : %s"
+
+#~ msgid "High"
+#~ msgstr "Élevé"
+
+#~ msgid "Low"
+#~ msgstr "Faible"
+
+#~ msgid "Manual"
+#~ msgstr "Manuel"
+
+#~ msgid "Mass"
+#~ msgstr "En masse"
+
+#~ msgid "Message"
+#~ msgstr "Message"
+
+#, python-format
+#~ msgid "Missing message on request %s."
+#~ msgstr "Message manquant sur la requête %s."
+
+#, python-format
+#~ msgid ""
+#~ "Missing mobile phone number on signatory '%s' whose authentication mode "
+#~ "is SMS"
+#~ msgstr ""
+#~ "Numéro de téléphone portable manquant sur le signataire '%s' dont le mode "
+#~ "d'authentification est SMS"
+
+#~ msgid "Partially Signed"
+#~ msgstr "Partiellement signé"
+
+#~ msgid "Photo"
+#~ msgstr "Photo"
+
+#~ msgid "Proof Level"
+#~ msgstr "Niveau de preuve"
+
+#~ msgid ""
+#~ "Proof level of the signer. In HIGH mode, signer(s) must upload ID cards "
+#~ "to launch the signature (it will be checked immediately after the upload)"
+#~ msgstr ""
+#~ "Niveau de preuve du signataire. En mode élevé, les signataires doivent "
+#~ "déposer une copie d'une pièce d'identité (elle sera vérifiée juste après "
+#~ "le dépôt)"
+
+#, python-format
+#~ msgid "Reminder sent to late signatories"
+#~ msgstr "Relance envoyée aux signataires retardataires"
+
+#~ msgid "Title"
+#~ msgstr "Titre"
+
+#~ msgid "To be set only when Authentication Mode is Manual"
+#~ msgstr ""
+#~ "À renseigner uniquement quand le mode d'authentification est 'manuel'"
+
+#, python-format
+#~ msgid ""
+#~ "You have selected 'manual' as authentication mode for the signatory %s, "
+#~ "so you must set the authentication value for this signatory."
+#~ msgstr ""
+#~ "Vous avez sélectionné le mode d'authentification 'manuel' pour le "
+#~ "signataire %s, donc vous devez entrer une valeur d'authentification pour "
+#~ "ce signataire."
+
+#~ msgid "Yousign Lang"
+#~ msgstr "Langue Yousign"
+
+#, python-format
+#~ msgid ""
+#~ "dynamic_partner_id is a required argument when partner_type is dynamic"
+#~ msgstr ""
+#~ "dynamic_partner_id is a required argument when partner_type is dynamic"

--- a/yousign_connector/models/yousign_request_template.py
+++ b/yousign_connector/models/yousign_request_template.py
@@ -53,6 +53,9 @@ class YousignRequestTemplate(models.Model):
     ir_value_id = fields.Many2one(
         'ir.values', string='Sidebar Button', readonly=True, copy=False,
         help="Sidebar button to open the sidebar action")
+    sign_position = fields.Selection(
+        [('top', 'Top'), ('bottom', 'Bottom')],
+        string='Sign position', default='top')
 
     _sql_constraints = [
         (
@@ -113,6 +116,7 @@ class YousignRequestTemplate(models.Model):
             'remind_auto': self.remind_auto,
             'remind_interval': self.remind_interval,
             'remind_limit': self.remind_limit,
+            'sign_position': self.sign_position,
             }
         return res
 

--- a/yousign_connector/views/yousign_request.xml
+++ b/yousign_connector/views/yousign_request.xml
@@ -26,6 +26,7 @@
                     <field name="res_name"/>
                     <field name="model" invisible="0"/>
                     <field name="res_id" invisible="0"/>
+                    <field name="sign_position"/>
                     <field name="ordered"/>
                     <field name="attachment_ids" widget="many2many_binary"/>
                     <field name="signed_attachment_ids" widget="many2many_binary" states="archived,cancel"/>

--- a/yousign_connector/views/yousign_request.xml
+++ b/yousign_connector/views/yousign_request.xml
@@ -79,6 +79,7 @@
                 <field name="res_name" invisible="1"/>
                 <field name="model" invisible="1"/>
                 <field name="res_id" invisible="1"/>
+                <field name="sign_position"/>
                 <field name="state" invisible="1"/>
                 <field name="company_id" groups="base.group_multi_company" invisible="1"/>
                 <field name="attachment_ids" widget="many2many_binary"/>

--- a/yousign_connector/views/yousign_request_template.xml
+++ b/yousign_connector/views/yousign_request_template.xml
@@ -29,6 +29,7 @@
                 <field name="name"/>
                 <field name="model_id"/>
                 <field name="model" invisible="1"/>
+                <field name="sign_position"/>
                 <field name="ordered"/>
                 <field name="lang"/>
                 <field name="report_id" domain="[('model','=', model)]"/>


### PR DESCRIPTION
Added a field selection to define the main position of the signature top [default] or bottom.

The position is defined on the request model, and copied on the request. 